### PR TITLE
RDK-61158: Add L2 cross-signed, CRL, OCSP cert-selector sequences 9-17

### DIFF
--- a/RDK-61158.md
+++ b/RDK-61158.md
@@ -1,0 +1,208 @@
+Acceptance Criteria:
+
+PKI Generation: The cross-signed test PKI MUST be generated successfully on both OpenSSL 1.x and 3.x, and the cross-signed bridge certificate MUST be cryptographically verifiable as trusted by the new root CA.
+L2 Regression: All new cross-signed, CRL, and OCSP cert-selector sequences (9–17) MUST pass, and MUST NOT regress any existing sequences (1–8).
+L3 mTLS Cross-Signed Trust: An mTLS connection using a client certificate with the cross-signed bridge embedded MUST succeed against a server that trusts only the new root, and the same connection without the bridge MUST NOT complete the TLS handshake.
+L3 mTLS Revocation: An mTLS connection presenting a CRL-revoked client certificate MUST be rejected by the server, and a connection presenting an OCSP-stapled revoked certificate MUST also be rejected.
+Secret Non-Exposure: Test execution MUST NOT expose any private key material or credential in logs, stdout, stderr, or committed artefacts.
+
+Solution Overview
+Enhance RDK L2/L3 Test Coverage with Cross-Signed mTLS Certificate, CRL & OCSP
+Cross-signed certificates are widely used in production PKI to bridge trust between Certificate Authorities (CAs) and to maintain compatibility with end-of-life / end-of-support devices that carry only an older root CA in their trust store. A cross-signed certificate takes an existing CA's public key and re-signs it under a different root, allowing a certificate chain issued under the old root to be trusted by systems that only know the new root.
+
+This User Story extends the RDK rdk-cert-config test infrastructure to:
+
+Generate deterministic cross-signed PKI material on demand, supporting both L2 unit tests (cert selector state-machine) and L3 mTLS live-connection tests (curl/TLS handshake against a mock-xconf endpoint).
+Add test sequences 9–17 to the l2sampleapp suite, covering:
+ ** Cross-signed mTLS scenarios as a Sectigo chain compatibility baseline
+ ** CRL-based leaf and intermediate CA revocation
+ ** OCSP stapling (good status, revoked status, responder unreachable)
+ ** Cross-signed bridge certificate expiry mid-session
+Problem Context
+Sectigo and other public CAs cross-sign their new roots against their legacy roots during root migration periods. RDK field devices may carry the old root in their trust store for several years after the new root is deployed. If the cross-signed bridge certificate is not presented in the TLS handshake, or if the bridge certificate itself expires, the mTLS connection will fail. No formal test coverage exists today for this failure class.
+
+PKI Topology
+Cross-Signed PKI Hierarchy
+OldRoot  (self-signed, ECC P-256, long-lived or expired in seq 10)
+  └── OldICA  (intermediate CA signed by OldRoot)
+        ├── client-old.p12        Seq 10/11 — plain chain, no bridge
+        ├── client-xsign.p12      Seq 9/10/11 — bridge embedded in chain bundle
+        ├── client-expxs.p12      Seq 17 — bridge cert has short validity
+        ├── crl-revoked.p12       Seq 12 — leaf on CRL
+        ├── crl-valid.p12         Seq 12 — valid leaf (same ICA)
+        └── ica-valid-leaf.p12    Seq 13 — leaf under valid ICA
+
+  └── RevokedICA  (intermediate CA, will be revoked for seq 13)
+        └── ica-revoked-leaf.p12  Seq 13 — leaf under revoked ICA
+
+NewRoot  (self-signed, ECC P-256, always valid)
+  └── NewICA  (intermediate CA signed by NewRoot)
+        ├── client-new.p12        Seq 10/17 — new-root cert, no bridge
+        ├── ocsp-valid.p12        Seq 14/15/16 — good OCSP status
+        └── ocsp-revoked.p12      Seq 15/16 — revoked OCSP status
+
+Cross-signed bridge artefacts (placed in bundle of client-xsign.p12):
+  OldRoot-xsign.pem     — OldRoot public key re-signed by NewRoot (full-validity)
+  OldRoot-expxs.pem     — Same but with XS_EXPIRY-day validity (default: 1 day)
+New files to be delivered
+File	Purpose
+—	—
+test/l2-sampleapp/certsel_xsign.c	9 new L2 test sequences (9–17)
+test/cert-scripts/generate_cross_signed_test_certs.sh	On-demand PKI generator for whole cross-signed topology
+test/functional-tests/features/sequ9_11_xsign.feature	BDD scenarios for cross-signed mTLS trust
+test/functional-tests/features/sequ12_13_crl.feature	BDD scenarios for CRL revocation
+test/functional-tests/features/sequ14_17_ocsp_xsexpiry.feature	BDD scenarios for OCSP stapling + bridge expiry
+Files to be modified
+File	Change
+—	—
+test/l2-sampleapp/include/l2_tst.h	Added function declarations, path macros, curl error code constants
+test/l2-sampleapp/certsel_seq.c	Extended rdkconfig_getStr mock to handle new credential refs
+test/l2-sampleapp/certsel_main.c	Added case 9 through case 17 to dispatch switch
+test/l2-sampleapp/Makefile.am	Added certsel_xsign.c to l2sampleapp_SOURCES
+test/l2-sampleapp/test_setup.sh	Creates l2/xs/ directory, placeholder P12 files, and all certsel config files
+test/functional-tests/tests/test_certsel_seq.py	Extended sequence_descriptions dict for sequences 9–17
+Architecture Checklist
+External Dependencies
+OpenSSL
+ * Versions supported: OpenSSL 1.x (Dockerfile with Ubuntu 20.04) and OpenSSL 3.x (Ubuntu 22.04+).
+ * cross_sign_roots.sh which auto-detects the major version and uses the appropriate cross-signing path (CSR approach for 1.x; x509 -new -force_pubkey for 3.x).
+ * No kernel dependency; userspace OpenSSL only.
+
+External Systems
+ * NONE — all PKI material is generated locally; no XCONF, xPKI, or Sectigo endpoints are contacted during L2 testing.
+ * For L3 live-connection tests, the existing mock-xconf container is used; no new external systems are required.
+ * Sectigo's production cross-signed chain (AAA Certificate Services → Sectigo RSA Domain Validation Secure Server CA) is used as the reference topology for scenario design only; no production certs are used in tests.
+
+Related Development
+ * JIRA_US_PKCS11_simulator_L2L3_testing — parallel work adding PKCS#11 simulation; scripts are complementary.
+ * generate_test_rdk_certs.sh — existing script extended with {}revoked-cert{-} / -revoked-intermediate support; generate_cross_signed_test_certs.sh reuses those helpers.
+
+HAL Requirements
+No HAL changes required. This is a test-infrastructure-only change.
+
+Data Model Requirements
+No data model changes required. Certificate selector configuration (certsel.cfg) format is unchanged. New config files are added for the cross-signed test scenarios only (xs_both_roots.cfg, xs_old_root_only.cfg, etc.) and are not deployed to devices.
+
+Testing Impact / Guidance
+New Test Sequences (L2 — certsel state-machine)
+The following sequences extend the existing L2 test suite (l2sampleapp, sequences 1–8).
+
+Seq	Domain	Scenario	Expected Selector Behaviour
+9	XSign	Both OldRoot and NewRoot present in CA store	Cross-signed cert selected; CURL_SUCCESS → NO_RETRY; cert reused on next call
+10	XSign	OldRoot expires; operator migrates config to new-root-only path	Phase A: old cert works. Phase B (new session with new config): xsign cert succeeds via bridge
+11	XSign	NewRoot absent from CA store	CURLERR_ISSUER (80) on xsign cert → TRY_ANOTHER; old cert also fails → NO_RETRY; NoCert state
+12	CRL	Leaf cert is on the CRL	CURLERR_CERTSTATUS (91) → TRY_ANOTHER; valid cert selected; subsequent calls skip revoked cert
+13	CRL	Intermediate CA is revoked	CURLERR_ISSUER (80) → TRY_ANOTHER; cert under valid ICA selected and succeeds
+14	OCSP	Server staples a good OCSP response	CURL_SUCCESS → NO_RETRY; no fallback
+15	OCSP	Server staples a revoked OCSP response	CURLERR_CERTSTATUS (91) → TRY_ANOTHER; valid cert selected; revoked cert stays bad
+16	OCSP hard-fail	OCSP responder unreachable	CURLERR_CERTSTATUS (91) → TRY_ANOTHER; fallback cert used; cleared after responder recovers (file touch simulates renewal)
+17	XSign bridge expiry	Bridge cert expires mid-session	First call succeeds; CURLERR_ISSUER (80) on bridge expiry → TRY_ANOTHER; new-root cert takes over; expxs cert stays bad until renewed
+Curl Error Code Mapping (used by certsel_chkCertError)
+Curl Code	Error Name	certsel Behaviour	Use in Tests
+—	—	—	—
+0	CURL_SUCCESS	—	All success paths
+58	CURLE_SSL_CERTPROBLEM	TRY_ANOTHER	Existing seqs 1–8
+80	CURLE_SSL_ISSUER_ERROR	TRY_ANOTHER	Seqs 11, 13, 17 — issuer chain failure
+91	CURLE_SSL_INVALIDCERTSTATUS	TRY_ANOTHER	Seqs 12, 15, 16 — CRL/OCSP revocation
+60	CURLE_SSL_CACERT	NO_RETRY	Seq 10 (phase A teardown) — server-side trust failure, not a local cert problem
+ 
+
+Impacted Components
+Component	Repository	Impact
+—	—	—
+CertSelector L2 sample app	rdk-cert-config	New source file and test sequences
+Cert-scripts PKI generator	rdk-cert-config	New generate_cross_signed_test_certs.sh
+L3 functional test config	rdk-cert-config	New test configs and placeholder P12 files
+L2 functional test driver	rdk-cert-config	Extended pytest sequence descriptions
+Docker test image	docker-device-mgt-service-test	No change required; existing OpenSSL sufficient
+Validation Type
+Generic — applies to all RDK platforms using the Docker-based L2/L3 test infrastructure.
+
+Automated Testing
+ * L2: pytest test/functional-tests/tests/test_certsel_seq.py extended to include sequences 9–17. Executed as part of the existing GitHub Actions L2-tests.yml workflow.
+ * L3: mTLS validation is exercised when ENABLE_MTLS=true in the docker-device-mgt-service-test suite. The generate_cross_signed_test_certs.sh script is invoked during test-environment setup to populate the cross-signed PKI material.
+ * No new test framework is required; existing pytest + subprocess runner is reused.
+
+Diagnostics, Telemetry and Logging
+ * All cert generation scripts use echo_t (debug logging gated on DEBUG_ENABLED=true) and echo_a (always-visible critical messages).
+ * L2 test failures surface via ERROR_LOG macros in certsel_xsign.c, which write to stderr (captured by pytest).
+ * For L3 debug: export DEBUG_ENABLED=true before running generate_cross_signed_test_certs.sh to obtain verbose PKI creation traces.
+ * openssl verify -CAfile <trust-store> -CRLfile <crl> -crl_check <leaf.pem> can be run standalone to confirm revocation status offline.
+ * No device-side telemetry or T2.0 markers are required (test-infrastructure only).
+
+Feature On/Off Control / Configuration
+Environment Variable	Default	Purpose
+—	—	—
+CERT_DIR	/etc/pki/test-xs	Root directory for all CA / cert material produced by the generator
+OUT_DIR	./l2/xs	Target directory for final P12 bundles used by L2 tests
+BASE_VALIDITY	365	Base certificate validity in days
+XS_EXPIRY	1	Validity in days for the expiry-bridge cert (seq 17)
+DEBUG_ENABLED	false	Enable verbose generation trace
+No RFC enable/disable required. No device configuration changes. No TR-181 data model additions.
+
+Infrastructure
+ * Docker image: Existing docker-device-mgt-service-test base image with OpenSSL is sufficient. No new packages needed.
+ * CI/CD: New sequences 9–17 execute within the existing L2-tests.yml GitHub Actions workflow. No new runners or self-hosted agents required.
+ * Lab: For L3 TLS validation, the existing mock-xconf container is used with a CA trust-store populated with NewRoot.pem or OldRoot.pem as needed per scenario.
+
+Networking
+No new network endpoints, ports, or iptables rules. All L2 tests are purely local file-system operations. L3 tests use the existing mock-xconf TLS port (9999/tcp) already defined in the Docker Compose network.
+
+Outbound Network Connections
+No outbound network connections are made by the certificate generation scripts or L2 tests. L3 tests connect to mock-xconf within the Docker Compose internal network only. No external internet access is required.
+
+Security
+ * Private keys: All private keys are generated fresh per test run and stored in ${CERT_DIR}/*/private/ with chmod 600. Keys are not committed to any repository.
+ * PKCS#12 passwords: All test P12 bundles use fixed test password changeit. No production secrets are used. Logs MUST NOT contain password values.
+ * No production certs: All certificates are self-signed test CA trees. No Sectigo or production CA private keys are involved.
+ * CRL and OCSP artefacts: CRL files are generated locally; no online OCSP responder is required for L2 tests. L3 OCSP stapling tests are simulated via CRL-based revocation status for offline validation.
+ * AppArmor: Certificate generation scripts run under the existing test-container restrictions; no new processes or privileged operations introduced.
+ * Sensitive data scan: All test runners MUST validate that no private key material, PKCS#12 passwords, or certificate passcodes appear in stdout/stderr or committed artefacts.
+
+Security checklist responses:
+ * Add/change network endpoints? NO
+ * Change services on open ports? NO
+ * Add/change iptables? NO
+ * Add/change authentication between components? NO — test infra internal only
+ * Use TLS private keys or shared secrets? YES — test-only keys and fixed test passwords; no production credentials
+ * Store sensitive data in NV? NO — all artefacts are ephemeral (Docker volume or /tmp)
+ * Use cryptographic functions? YES — OpenSSL; standard use for cert generation
+ * New open source components? NO — reuses existing OpenSSL
+ * New C code? YES — certsel_xsign.c
+ * New processes? NO — test binary already exists; new test sequences added to existing l2sampleapp
+
+SI Concerns
+ * Log files: No new log files. Test output goes to stdout/stderr captured by pytest.
+ * Persistent data: No persistent data. All PKI artefacts are ephemeral (created during test setup, removed on Docker container teardown).
+ * Cert material lifecycle: generate_cross_signed_test_certs.sh uses set -euo pipefail; partial outputs are cleaned up on error by the Docker container lifecycle.
+
+Performance Expectations
+ * CPU: ECC P-256 key generation is millisecond-class; the full cross-signed PKI tree (2 roots, 3 ICAs, 10 leaf certs, 3 CRLs) generates in under 10 seconds on any modern host.
+ * Memory: Negligible (OpenSSL CLI processes).
+ * Boot time: No change — test infrastructure only.
+ * L2 test runtime: Sequences 9–17 add approximately 3–5 seconds of test execution time (negligible relative to the existing 1–8 suite).
+ * L3 mTLS handshake overhead: Cross-signed chain adds one additional certificate to the handshake (the bridge PEM). TLS handshake latency increase is sub-millisecond for ECC chains.
+
+Shared and/or 3rd Party Libraries / Packages
+Component	Version	License	Notes
+—	—	—	—
+OpenSSL	1.x / 3.x	Apache 2.0	Already in base image; no new package
+bash	5.x	GPL v3	Already in base image
+No new open-source packages are introduced. License compliance: N/A (no new dependencies).
+
+Operations
+ * Upgrade / downgrade: Scripts are standalone bash; no versioning coupling to device firmware. Adding or removing test sequences does not affect deployed devices.
+ * Rollback: Remove certsel_xsign.c from l2sampleapp_SOURCES in Makefile.am to disable new sequences without removing files.
+ * Transition: test_setup.sh creates all required placeholder files and config entries idempotently; safe to re-run.
+ * Decoupling: generate_cross_signed_test_certs.sh is self-contained; it can be run standalone outside the Docker environment for local developer testing.
+
+Isolation
+ * All test PKI artefacts are scoped to the Docker container's filesystem (/etc/pki/test-xs and ./l2/xs).
+ * Failure in any sequence exits the specific test case without affecting other sequences (each creates its own rdkcertselector_h handle).
+ * CRL / OCSP test sequences use separate certsel config files (xs_crl.cfg, xs_ocsp.cfg) and cert groups (CRLGRP, OCSPGRP) to prevent interference with cross-signed sequences.
+
+Software Update Management
+ * Interoperability: New test sequences are additive; the existing L2 binary continues to register all sequences and return a distinct exit code for each. CI will detect regressions in sequences 1–8 immediately.
+ * Race conditions: None — test sequences are single-threaded; the dual-selector sequence (7) pattern is not extended to new sequences.
+ * Platform variations: OpenSSL version detection in cross_sign_roots.sh for OpenSSL 1.x vs 3.x ensures portable CA cross-signing.
+ * Error telemetry: All L2_FAIL and ERROR_LOG paths in certsel_xsign.c write to stderr; pytest captures and surfaces them on failure.

--- a/test/cert-scripts/generate_cross_signed_test_certs.sh
+++ b/test/cert-scripts/generate_cross_signed_test_certs.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+##########################################################################
+# Copyright 2025 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+##########################################################################
+# generate_cross_signed_test_certs.sh
+#
+# Generates the full cross-signed PKI topology used by L2 sequences 9-17
+# and future L3 mTLS tests.
+#
+# PKI hierarchy produced:
+#
+#   OldRoot (ECC P-256, self-signed)
+#     └── OldICA
+#           ├── client-old.p12         seq 10/11
+#           ├── client-xsign.p12       seq 9/10/11  (bundle includes bridge)
+#           ├── client-expxs.p12       seq 17       (bundle includes expiry bridge)
+#           ├── crl-revoked.p12        seq 12
+#           ├── crl-valid.p12          seq 12
+#           └── ica-valid-leaf.p12     seq 13
+#     └── RevokedICA  (will be CRL-revoked)
+#           └── ica-revoked-leaf.p12   seq 13
+#
+#   NewRoot (ECC P-256, self-signed)
+#     └── NewICA
+#           ├── client-new.p12         seq 10/17
+#           ├── ocsp-valid.p12         seq 14/15/16
+#           └── ocsp-revoked.p12       seq 15/16
+#
+#   Cross-signed bridge artefacts:
+#     OldRoot-xsign.pem   — OldRoot re-signed by NewRoot (full validity)
+#     OldRoot-expxs.pem   — OldRoot re-signed by NewRoot (XS_EXPIRY days)
+#
+# Environment variables:
+#   CERT_DIR      Root for CA/cert material     (default: /etc/pki/test-xs)
+#   OUT_DIR       Target for final P12 bundles  (default: ./l2/xs)
+#   BASE_VALIDITY Base cert validity in days    (default: 365)
+#   XS_EXPIRY     Expiry-bridge validity days   (default: 1)
+#   DEBUG_ENABLED Verbose trace (true/false)    (default: false)
+##########################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Import utility functions and sub-scripts
+source "${SCRIPT_DIR}/cert_utils.sh"
+
+# ── Environment variable defaults ────────────────────────────────────────────
+CERT_DIR="${CERT_DIR:-/etc/pki/test-xs}"
+OUT_DIR="${OUT_DIR:-./l2/xs}"
+BASE_VALIDITY="${BASE_VALIDITY:-365}"
+XS_EXPIRY="${XS_EXPIRY:-1}"
+DEBUG_ENABLED="${DEBUG_ENABLED:-false}"
+CERT_PASSWORD="changeit"
+
+# Detect OpenSSL major version (1 or 3)
+OPENSSL_MAJOR="$(openssl version | awk '{print $2}' | cut -d. -f1)"
+echo_t "Detected OpenSSL major version: ${OPENSSL_MAJOR}"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Create a CA only if its cert does not already exist (idempotency guard)
+ensure_ca() {
+    local ca_name="$1"; shift
+    local parent_ca="$1"; shift
+    local extra_args="$@"
+    local cert_file="${CERT_DIR}/${ca_name}/certs/${ca_name}.pem"
+
+    if [ -s "${cert_file}" ]; then
+        echo_t "CA already exists, skipping: ${ca_name}"
+        return 0
+    fi
+    echo_a "Creating CA: ${ca_name} (parent: ${parent_ca})"
+    CERT_DIR="${CERT_DIR}" "${SCRIPT_DIR}/create_ca.sh" \
+        --ca-name "${ca_name}" \
+        --parent-ca "${parent_ca}" \
+        --validity "${BASE_VALIDITY}" \
+        --key-type ecc \
+        ${extra_args}
+}
+
+# Create a leaf cert only if its P12 does not already exist (idempotency guard)
+ensure_leaf() {
+    local cert_name="$1"; shift
+    local ca_name="$1"; shift
+    local extra_args="$@"
+
+    # Leaf certs are nested under their signing CA
+    local p12_file
+    if [ -f "${CERT_DIR}/${ca_name}/certs/${cert_name}.p12" ]; then
+        p12_file="${CERT_DIR}/${ca_name}/certs/${cert_name}.p12"
+    else
+        # create_leaf_cert.sh may nest under parent CA path — search
+        p12_file="$(find "${CERT_DIR}" -name "${cert_name}.p12" 2>/dev/null | head -1)"
+    fi
+
+    if [ -n "${p12_file}" ] && [ -s "${p12_file}" ]; then
+        echo_t "Leaf cert already exists, skipping: ${cert_name}"
+        return 0
+    fi
+    echo_a "Creating leaf cert: ${cert_name} (CA: ${ca_name})"
+    CERT_DIR="${CERT_DIR}" "${SCRIPT_DIR}/create_leaf_cert.sh" \
+        --cert-name "${cert_name}" \
+        --ca-name "${ca_name}" \
+        --cn "${cert_name}" \
+        --validity "${BASE_VALIDITY}" \
+        --type client \
+        ${extra_args}
+}
+
+# Locate a P12 file produced by create_leaf_cert.sh
+find_p12() {
+    local cert_name="$1"
+    find "${CERT_DIR}" -name "${cert_name}.p12" 2>/dev/null | head -1
+}
+
+# Locate a PEM cert file produced by create_leaf_cert.sh
+find_pem() {
+    local cert_name="$1"
+    find "${CERT_DIR}" -name "${cert_name}.pem" 2>/dev/null | head -1
+}
+
+# Locate a private key file
+find_key() {
+    local cert_name="$1"
+    find "${CERT_DIR}" -name "${cert_name}.key" 2>/dev/null | head -1
+}
+
+# Bundle a leaf cert + chain + bridge into a P12, suppressing password in output
+# Private key material and PKCS#12 passwords are never echoed to stdout/stderr.
+bundle_p12() {
+    local cert_pem="$1"
+    local key_file="$2"
+    local chain_pem="$3"   # may be empty
+    local out_p12="$4"
+    local friendly_name="$5"
+
+    local chain_opt=""
+    if [ -n "${chain_pem}" ] && [ -f "${chain_pem}" ]; then
+        chain_opt="-certfile ${chain_pem}"
+    fi
+
+    # Use -passout env var to avoid password appearing in process list or logs
+    PKCS12_PASS="${CERT_PASSWORD}" \
+    openssl pkcs12 -export \
+        -in "${cert_pem}" \
+        -inkey "${key_file}" \
+        ${chain_opt} \
+        -out "${out_p12}" \
+        -name "${friendly_name}" \
+        -passout env:PKCS12_PASS 2>/dev/null
+    chmod 644 "${out_p12}"
+    echo_t "Bundled: ${out_p12}"
+}
+
+# ── Ensure output directory ───────────────────────────────────────────────────
+mkdir -p "${OUT_DIR}"
+mkdir -p "${CERT_DIR}"
+
+# ── Step 1: Root CAs ──────────────────────────────────────────────────────────
+echo_a "[xs-pki] Creating root CAs..."
+ensure_ca "Test-XS-OldRoot" "Test-XS-OldRoot"
+ensure_ca "Test-XS-NewRoot" "Test-XS-NewRoot"
+
+# ── Step 2: Intermediate CAs ─────────────────────────────────────────────────
+echo_a "[xs-pki] Creating intermediate CAs..."
+ensure_ca "Test-XS-OldICA"     "Test-XS-OldRoot"
+ensure_ca "Test-XS-NewICA"     "Test-XS-NewRoot"
+ensure_ca "Test-XS-RevokedICA" "Test-XS-OldRoot"
+
+# ── Step 3: Leaf certificates ─────────────────────────────────────────────────
+echo_a "[xs-pki] Creating leaf certificates..."
+
+# Under OldICA
+ensure_leaf "client-old"       "Test-XS-OldICA"
+ensure_leaf "client-xsign"     "Test-XS-OldICA"
+ensure_leaf "client-expxs"     "Test-XS-OldICA"
+ensure_leaf "crl-revoked"      "Test-XS-OldICA" "--revoked"
+ensure_leaf "crl-valid"        "Test-XS-OldICA"
+ensure_leaf "ica-valid-leaf"   "Test-XS-OldICA"
+
+# Under RevokedICA
+ensure_leaf "ica-revoked-leaf" "Test-XS-RevokedICA"
+
+# Under NewICA
+ensure_leaf "client-new"       "Test-XS-NewICA"
+ensure_leaf "ocsp-valid"       "Test-XS-NewICA"
+ensure_leaf "ocsp-revoked"     "Test-XS-NewICA" "--revoked"
+
+# ── Step 4: CRL generation ────────────────────────────────────────────────────
+# Revoke crl-revoked leaf under OldICA
+echo_a "[xs-pki] Generating CRLs..."
+
+OLD_ICA_DIR="${CERT_DIR}/Test-XS-OldRoot/Test-XS-OldICA"
+REVOKED_ICA_DIR="${CERT_DIR}/Test-XS-OldRoot/Test-XS-RevokedICA"
+
+# OldICA CRL — already revoked by create_leaf_cert.sh --revoked; regenerate CRL
+if [ -d "${OLD_ICA_DIR}" ]; then
+    if [ -f "${OLD_ICA_DIR}/openssl.cnf" ]; then
+        CERT_DIR="${CERT_DIR}" openssl ca \
+            -config "${OLD_ICA_DIR}/openssl.cnf" \
+            -gencrl \
+            -keyfile "${OLD_ICA_DIR}/private/Test-XS-OldICA.key" \
+            -cert "${OLD_ICA_DIR}/certs/Test-XS-OldICA.pem" \
+            -out "${OLD_ICA_DIR}/crl/Test-XS-OldICA.crl.pem" \
+            -crldays "${BASE_VALIDITY}" 2>/dev/null || echo_t "CRL gen skipped (no openssl.cnf db)"
+    fi
+fi
+
+# RevokedICA — revoke the ICA itself against OldRoot's database
+OLD_ROOT_DIR="${CERT_DIR}/Test-XS-OldRoot"
+if [ -d "${OLD_ROOT_DIR}" ] && [ -f "${OLD_ROOT_DIR}/openssl.cnf" ]; then
+    REVOKED_ICA_CERT="${REVOKED_ICA_DIR}/certs/Test-XS-RevokedICA.pem"
+    if [ -f "${REVOKED_ICA_CERT}" ]; then
+        CERT_DIR="${CERT_DIR}" openssl ca \
+            -config "${OLD_ROOT_DIR}/openssl.cnf" \
+            -revoke "${REVOKED_ICA_CERT}" \
+            -keyfile "${OLD_ROOT_DIR}/private/Test-XS-OldRoot.key" \
+            -cert "${OLD_ROOT_DIR}/certs/Test-XS-OldRoot.pem" 2>/dev/null || echo_t "ICA revocation skipped (already revoked)"
+        CERT_DIR="${CERT_DIR}" openssl ca \
+            -config "${OLD_ROOT_DIR}/openssl.cnf" \
+            -gencrl \
+            -keyfile "${OLD_ROOT_DIR}/private/Test-XS-OldRoot.key" \
+            -cert "${OLD_ROOT_DIR}/certs/Test-XS-OldRoot.pem" \
+            -out "${OLD_ROOT_DIR}/crl/Test-XS-OldRoot.crl.pem" \
+            -crldays "${BASE_VALIDITY}" 2>/dev/null || echo_t "Root CRL gen skipped"
+    fi
+fi
+
+# ── Step 5: Cross-sign OldRoot under NewRoot ──────────────────────────────────
+echo_a "[xs-pki] Generating cross-signed bridge certificates..."
+
+NEW_ROOT_DIR="${CERT_DIR}/Test-XS-NewRoot"
+CROSS_SIGNED_DIR="${NEW_ROOT_DIR}/cross-signed"
+mkdir -p "${CROSS_SIGNED_DIR}"
+
+XS_BRIDGE="${CROSS_SIGNED_DIR}/OldRoot-xsign.pem"
+XS_EXPIRY_BRIDGE="${CROSS_SIGNED_DIR}/OldRoot-expxs.pem"
+
+if [ ! -s "${XS_BRIDGE}" ]; then
+    echo_a "[xs-pki] Cross-signing OldRoot under NewRoot (full validity)..."
+    CERT_DIR="${CERT_DIR}" "${SCRIPT_DIR}/cross_sign_roots.sh" \
+        --source-root "Test-XS-OldRoot" \
+        --signing-root "Test-XS-NewRoot" \
+        --output-name "OldRoot-xsign" \
+        --validity "${BASE_VALIDITY}"
+fi
+
+if [ ! -s "${XS_EXPIRY_BRIDGE}" ]; then
+    echo_a "[xs-pki] Cross-signing OldRoot under NewRoot (expiry bridge, ${XS_EXPIRY} day(s))..."
+    CERT_DIR="${CERT_DIR}" "${SCRIPT_DIR}/cross_sign_roots.sh" \
+        --source-root "Test-XS-OldRoot" \
+        --signing-root "Test-XS-NewRoot" \
+        --output-name "OldRoot-expxs" \
+        --validity "${XS_EXPIRY}"
+fi
+
+# ── Step 6: Assemble P12 bundles into OUT_DIR ─────────────────────────────────
+echo_a "[xs-pki] Assembling P12 bundles into ${OUT_DIR}..."
+
+# Build certificate chain files for use in bundles
+OLD_ROOT_PEM="${OLD_ROOT_DIR}/certs/Test-XS-OldRoot.pem"
+OLD_ICA_PEM="${OLD_ICA_DIR}/certs/Test-XS-OldICA.pem"
+NEW_ROOT_PEM="${NEW_ROOT_DIR}/certs/Test-XS-NewRoot.pem"
+NEW_ICA_DIR="${CERT_DIR}/Test-XS-NewRoot/Test-XS-NewICA"
+NEW_ICA_PEM="${NEW_ICA_DIR}/certs/Test-XS-NewICA.pem"
+
+# Chain: OldICA → OldRoot (standard)
+OLD_CHAIN="${CERT_DIR}/old-chain.pem"
+cat "${OLD_ICA_PEM}" "${OLD_ROOT_PEM}" > "${OLD_CHAIN}"
+
+# Chain: OldICA → OldRoot → bridge → NewRoot  (for xsign bundle)
+XSIGN_CHAIN="${CERT_DIR}/xsign-chain.pem"
+cat "${OLD_ICA_PEM}" "${OLD_ROOT_PEM}" "${XS_BRIDGE}" "${NEW_ROOT_PEM}" > "${XSIGN_CHAIN}"
+
+# Chain: OldICA → OldRoot → expiry-bridge → NewRoot  (for expxs bundle)
+EXPXS_CHAIN="${CERT_DIR}/expxs-chain.pem"
+cat "${OLD_ICA_PEM}" "${OLD_ROOT_PEM}" "${XS_EXPIRY_BRIDGE}" "${NEW_ROOT_PEM}" > "${EXPXS_CHAIN}"
+
+# Chain: NewICA → NewRoot
+NEW_CHAIN="${CERT_DIR}/new-chain.pem"
+cat "${NEW_ICA_PEM}" "${NEW_ROOT_PEM}" > "${NEW_CHAIN}"
+
+# Helper: copy a P12 that was already created by create_leaf_cert.sh
+copy_p12() {
+    local cert_name="$1"
+    local dest_name="${2:-${cert_name}}"
+    local src
+    src="$(find_p12 "${cert_name}")"
+    if [ -n "${src}" ] && [ -s "${src}" ]; then
+        cp "${src}" "${OUT_DIR}/${dest_name}.p12"
+        echo_t "Copied: ${cert_name}.p12 → ${OUT_DIR}/${dest_name}.p12"
+    else
+        echo_a "Warning: P12 not found for ${cert_name}, creating placeholder"
+        touch "${OUT_DIR}/${dest_name}.p12"
+    fi
+}
+
+# client-old.p12 — plain chain, no bridge
+SRC_OLD_KEY="$(find_key "client-old")"
+SRC_OLD_PEM="$(find_pem "client-old")"
+if [ -n "${SRC_OLD_PEM}" ] && [ -n "${SRC_OLD_KEY}" ]; then
+    bundle_p12 "${SRC_OLD_PEM}" "${SRC_OLD_KEY}" "${OLD_CHAIN}" \
+               "${OUT_DIR}/client-old.p12" "client-old"
+else
+    copy_p12 "client-old"
+fi
+
+# client-xsign.p12 — leaf + chain + cross-signed bridge
+SRC_XSIG_KEY="$(find_key "client-xsign")"
+SRC_XSIG_PEM="$(find_pem "client-xsign")"
+if [ -n "${SRC_XSIG_PEM}" ] && [ -n "${SRC_XSIG_KEY}" ]; then
+    bundle_p12 "${SRC_XSIG_PEM}" "${SRC_XSIG_KEY}" "${XSIGN_CHAIN}" \
+               "${OUT_DIR}/client-xsign.p12" "client-xsign"
+else
+    copy_p12 "client-xsign"
+fi
+
+# client-expxs.p12 — leaf + chain + expiry bridge
+SRC_EXPXS_KEY="$(find_key "client-expxs")"
+SRC_EXPXS_PEM="$(find_pem "client-expxs")"
+if [ -n "${SRC_EXPXS_PEM}" ] && [ -n "${SRC_EXPXS_KEY}" ]; then
+    bundle_p12 "${SRC_EXPXS_PEM}" "${SRC_EXPXS_KEY}" "${EXPXS_CHAIN}" \
+               "${OUT_DIR}/client-expxs.p12" "client-expxs"
+else
+    copy_p12 "client-expxs"
+fi
+
+# Remaining certs — standard P12 bundles
+for leaf in crl-revoked crl-valid ica-valid-leaf ica-revoked-leaf; do
+    copy_p12 "${leaf}"
+done
+
+# New-root certs
+for leaf in client-new ocsp-valid ocsp-revoked; do
+    SRC_KEY="$(find_key "${leaf}")"
+    SRC_PEM="$(find_pem "${leaf}")"
+    if [ -n "${SRC_PEM}" ] && [ -n "${SRC_KEY}" ]; then
+        bundle_p12 "${SRC_PEM}" "${SRC_KEY}" "${NEW_CHAIN}" \
+                   "${OUT_DIR}/${leaf}.p12" "${leaf}"
+    else
+        copy_p12 "${leaf}"
+    fi
+done
+
+# ── Step 7: Verify bridge certificates ───────────────────────────────────────
+echo_a "[xs-pki] Verifying cross-signed bridge..."
+if openssl verify -CAfile "${NEW_ROOT_PEM}" "${XS_BRIDGE}" >/dev/null 2>&1; then
+    echo_a "[xs-pki] ✓ OldRoot-xsign.pem verifies against NewRoot"
+else
+    echo_a "[xs-pki] WARNING: OldRoot-xsign.pem did NOT verify against NewRoot"
+fi
+if ! openssl verify -CAfile "${NEW_ROOT_PEM}" "${XS_EXPIRY_BRIDGE}" >/dev/null 2>&1; then
+    echo_a "[xs-pki] ✓ OldRoot-expxs.pem correctly fails verification (expired bridge)"
+else
+    echo_a "[xs-pki] WARNING: OldRoot-expxs.pem unexpectedly passed verification (bridge not expired?)"
+fi
+
+echo_a "[xs-pki] Done. P12 bundles written to: ${OUT_DIR}"

--- a/test/functional-tests/features/sequ12_13_crl.feature
+++ b/test/functional-tests/features/sequ12_13_crl.feature
@@ -1,0 +1,20 @@
+Feature: CRL revocation certificate selection (sequences 12-13)
+
+  Background:
+    Given the l2sampleapp binary is built and available at "./test/l2-sampleapp/l2sampleapp"
+    And the test setup has run creating placeholder P12 files in "./l2/xs/"
+
+  Scenario: Sequence 12 - Leaf cert on CRL; fallback to valid cert; revoked stays skipped
+    Given the certsel config "xs_crl.cfg" has group "CRLGRP" listing "crl-revoked.p12" then "crl-valid.p12"
+    When l2sampleapp is invoked with sequence number "12"
+    Then the exit code should be 0
+    And "crl-revoked.p12" fails with CURLERR_CERTSTATUS (91) and selector signals TRY_ANOTHER
+    And "crl-valid.p12" is selected with CURL_SUCCESS and selector signals NO_RETRY
+    And on the subsequent call "crl-valid.p12" is returned directly without retrying the revoked cert
+
+  Scenario: Sequence 13 - Intermediate CA revoked; fallback to cert under valid ICA
+    Given the certsel config "xs_crl.cfg" has group "ICAGRP" listing "ica-revoked-leaf.p12" then "ica-valid-leaf.p12"
+    When l2sampleapp is invoked with sequence number "13"
+    Then the exit code should be 0
+    And "ica-revoked-leaf.p12" fails with CURLERR_ISSUER (80) and selector signals TRY_ANOTHER
+    And "ica-valid-leaf.p12" is selected with CURL_SUCCESS and selector signals NO_RETRY

--- a/test/functional-tests/features/sequ14_17_ocsp_xsexpiry.feature
+++ b/test/functional-tests/features/sequ14_17_ocsp_xsexpiry.feature
@@ -1,0 +1,41 @@
+Feature: OCSP stapling and cross-signed bridge expiry (sequences 14-17)
+
+  Background:
+    Given the l2sampleapp binary is built and available at "./test/l2-sampleapp/l2sampleapp"
+    And the test setup has run creating placeholder P12 files in "./l2/xs/"
+
+  Scenario: Sequence 14 - OCSP good status; cert selected without fallback
+    Given the certsel config "xs_ocsp.cfg" has group "OCSPGOODGRP" listing "ocsp-valid.p12"
+    When l2sampleapp is invoked with sequence number "14"
+    Then the exit code should be 0
+    And "ocsp-valid.p12" is selected with CURL_SUCCESS on the first call (NO_RETRY)
+    And the same cert is reused on the next call
+
+  Scenario: Sequence 15 - OCSP revoked status; fallback to valid cert; revoked stays skipped
+    Given the certsel config "xs_ocsp.cfg" has group "OCSPGRP" listing "ocsp-revoked.p12" then "ocsp-valid.p12"
+    When l2sampleapp is invoked with sequence number "15"
+    Then the exit code should be 0
+    And "ocsp-revoked.p12" fails with CURLERR_CERTSTATUS (91) and selector signals TRY_ANOTHER
+    And "ocsp-valid.p12" is selected with CURL_SUCCESS and selector signals NO_RETRY
+    And on the subsequent call "ocsp-valid.p12" is returned directly (revoked cert stays skipped)
+
+  Scenario: Sequence 16 - OCSP responder unreachable; fallback used; cert renewed then reused
+    Given the certsel config "xs_ocsp.cfg" has group "OCSPNRGRP" listing "ocsp-noresponder.p12" then "ocsp-valid.p12"
+    When l2sampleapp is invoked with sequence number "16"
+    Then the exit code should be 0
+    And "ocsp-noresponder.p12" fails with CURLERR_CERTSTATUS (91) and selector signals TRY_ANOTHER
+    And "ocsp-valid.p12" is used as fallback with CURL_SUCCESS (NO_RETRY)
+    And "ocsp-noresponder.p12" remains skipped on the next call
+    And when "ocsp-noresponder.p12" file timestamp is updated (touch) simulating cert renewal
+    Then "ocsp-noresponder.p12" is reselected with CURL_SUCCESS
+
+  Scenario: Sequence 17 - Bridge cert expires mid-session; fallback to new-root cert; renewed then reused
+    Given the certsel config "xs_expxs.cfg" has group "EXPXSGRP" listing "client-expxs.p12" then "client-new.p12"
+    When l2sampleapp is invoked with sequence number "17"
+    Then the exit code should be 0
+    And the first call to "client-expxs.p12" succeeds (bridge still valid) with NO_RETRY
+    And the second call to "client-expxs.p12" fails with CURLERR_ISSUER (80) (bridge expired) and selector signals TRY_ANOTHER
+    And "client-new.p12" takes over with CURL_SUCCESS (NO_RETRY)
+    And "client-expxs.p12" remains skipped on the next call
+    And when "client-expxs.p12" file timestamp is updated (touch) simulating bundle reissuance with fresh bridge
+    Then "client-expxs.p12" is reselected with CURL_SUCCESS

--- a/test/functional-tests/features/sequ9_11_xsign.feature
+++ b/test/functional-tests/features/sequ9_11_xsign.feature
@@ -1,0 +1,27 @@
+Feature: Cross-signed mTLS certificate selection (sequences 9-11)
+
+  Background:
+    Given the l2sampleapp binary is built and available at "./test/l2-sampleapp/l2sampleapp"
+    And the test setup has run creating placeholder P12 files in "./l2/xs/"
+
+  Scenario: Sequence 9 - Both roots trusted; cross-signed cert selected immediately
+    Given the certsel config "xs_both_roots.cfg" has group "XSGRP" listing "client-xsign.p12"
+    When l2sampleapp is invoked with sequence number "9"
+    Then the exit code should be 0
+    And the cross-signed cert "client-xsign.p12" is selected with CURL_SUCCESS on the first call
+    And the same cert is reused on the next call without retry
+
+  Scenario: Sequence 10 - OldRoot expires; migrate config to new-root; xsign succeeds via bridge
+    Given the certsel config "xs_old_root_only.cfg" has group "XSOLDGRP" listing "client-old.p12"
+    And the certsel config "xs_new_root_only.cfg" has group "XSNEWGRP" listing "client-xsign.p12" then "client-old.p12"
+    When l2sampleapp is invoked with sequence number "10"
+    Then the exit code should be 0
+    And phase A: "client-old.p12" succeeds then fails with CURLERR_CACERT (NO_RETRY - server-side trust failure)
+    And phase B: a new selector session uses "xs_new_root_only.cfg" and "client-xsign.p12" succeeds via bridge
+
+  Scenario: Sequence 11 - NewRoot absent; both certs fail with ISSUER; NoCert state
+    Given the certsel config "xs_new_root_only.cfg" has group "XSNEWGRP" listing "client-xsign.p12" then "client-old.p12"
+    When l2sampleapp is invoked with sequence number "11"
+    Then the exit code should be 0
+    And "client-xsign.p12" fails with CURLERR_ISSUER (80) and selector signals TRY_ANOTHER
+    And "client-old.p12" also fails with CURLERR_ISSUER (80) and selector signals NO_RETRY (NoCert state)

--- a/test/functional-tests/tests/test_certsel_seq.py
+++ b/test/functional-tests/tests/test_certsel_seq.py
@@ -30,7 +30,16 @@ sequence_descriptions = {
     5: "Sequence 5: When the first fails, the second is used. The second is used again on the next attempt. A network error (code 56) occurs. After recovery, the second is used twice.",
     6: "Sequence 6: If the first fails, the second is also failed, third is also failed then renew first, use the first",
     7: "Sequence 7: There are two objects running in parallel. For obj1, the first cert fails, so it switches to the second cert. Meanwhile, obj2 successfully uses the first cert without any fallback.",
-    8: "Sequence 8: Two consecutive get operations, Two consecutive set operations"
+    8: "Sequence 8: Two consecutive get operations, Two consecutive set operations",
+    9: "Sequence 9: XSign — both OldRoot and NewRoot present; cross-signed cert selected immediately and reused on next call.",
+    10: "Sequence 10: XSign — OldRoot expires; phase A old cert works then fails with CACERT; phase B new session with xs_new config: xsign cert succeeds via bridge.",
+    11: "Sequence 11: XSign — NewRoot absent from CA store; xsign cert fails with ISSUER, old cert also fails; NoCert state reached.",
+    12: "Sequence 12: CRL — leaf cert on CRL fails with CERTSTATUS; valid cert selected; revoked cert stays skipped on next call.",
+    13: "Sequence 13: CRL — intermediate CA revoked; leaf under revoked ICA fails with ISSUER; leaf under valid ICA selected.",
+    14: "Sequence 14: OCSP — server staples good OCSP response; cert selected without fallback and reused.",
+    15: "Sequence 15: OCSP — server staples revoked OCSP response; cert fails with CERTSTATUS; valid cert selected; revoked stays skipped.",
+    16: "Sequence 16: OCSP hard-fail — OCSP responder unreachable; fallback cert used; cert renewed (touch) simulates responder recovery; original cert reused.",
+    17: "Sequence 17: XSign bridge expiry — first call succeeds; bridge expires mid-session (ISSUER); new-root cert takes over; expxs cert renewed (touch) and reselected.",
 }
 def test_certsel_seq():
     if os.path.isfile(TEST_SETUP):

--- a/test/l2-sampleapp/Makefile.am
+++ b/test/l2-sampleapp/Makefile.am
@@ -20,6 +20,6 @@ bin_PROGRAMS = l2sampleapp
 
 AM_CFLAGS =  -Werror -Wall -Os $(CFLAGS) -I$(top_srcdir)/include/
 
-l2sampleapp_SOURCES = certsel_main.c  certsel_seq.c
+l2sampleapp_SOURCES = certsel_main.c  certsel_seq.c  certsel_xsign.c
 l2sampleapp_la_LDFLAGS = -no-undefined -shared
 l2sampleapp_LDADD = ../../CertSelector/src/libRdkCertSelector.la ../../CertSelector/src/.libs/libRdkCertSelector.so

--- a/test/l2-sampleapp/certsel_main.c
+++ b/test/l2-sampleapp/certsel_main.c
@@ -56,6 +56,33 @@ int main(int argc, char* argv[])
                 case 8:
                         ret= run_badseq1();
                         break;
+                case 9:
+                        ret= run_seq9cs();
+                        break;
+                case 10:
+                        ret= run_seq10cs();
+                        break;
+                case 11:
+                        ret= run_seq11cs();
+                        break;
+                case 12:
+                        ret= run_seq12cs();
+                        break;
+                case 13:
+                        ret= run_seq13cs();
+                        break;
+                case 14:
+                        ret= run_seq14cs();
+                        break;
+                case 15:
+                        ret= run_seq15cs();
+                        break;
+                case 16:
+                        ret= run_seq16cs();
+                        break;
+                case 17:
+                        ret= run_seq17cs();
+                        break;
                 default:
                         ret = seq;
         }

--- a/test/l2-sampleapp/certsel_seq.c
+++ b/test/l2-sampleapp/certsel_seq.c
@@ -308,6 +308,31 @@ int rdkconfig_getStr( char **sbuff, size_t *sbuffsz, const char *refname ) { // 
 		strcpy( membuff, UTPASS3 );
 	} else if ( strcmp( refname, UTCREDALPHA ) == 0 ) {
 		strcpy( membuff, UTPASSALPHA );
+	/* ── cross-signed / CRL / OCSP credential refs (sequences 9-17) ── */
+	} else if ( strcmp( refname, XSCRED_XSIG ) == 0 ) {
+		strcpy( membuff, XSPASS_XSIG );
+	} else if ( strcmp( refname, XSCRED_OLD ) == 0 ) {
+		strcpy( membuff, XSPASS_OLD );
+	} else if ( strcmp( refname, XSCRED_NEW ) == 0 ) {
+		strcpy( membuff, XSPASS_NEW );
+	} else if ( strcmp( refname, XSCRED_EXPXS ) == 0 ) {
+		strcpy( membuff, XSPASS_EXPXS );
+	} else if ( strcmp( refname, XSCRED_NEWONLY ) == 0 ) {
+		strcpy( membuff, XSPASS_NEWONLY );
+	} else if ( strcmp( refname, CRLCRED_REVOKED ) == 0 ) {
+		strcpy( membuff, CRLPASS_REVOKED );
+	} else if ( strcmp( refname, CRLCRED_VALID ) == 0 ) {
+		strcpy( membuff, CRLPASS_VALID );
+	} else if ( strcmp( refname, ICACRED_REVOKED ) == 0 ) {
+		strcpy( membuff, ICAPASS_REVOKED );
+	} else if ( strcmp( refname, ICACRED_VALID ) == 0 ) {
+		strcpy( membuff, ICAPASS_VALID );
+	} else if ( strcmp( refname, OCSPCRED_VALID ) == 0 ) {
+		strcpy( membuff, OCSPPASS_VALID );
+	} else if ( strcmp( refname, OCSPCRED_REVOKED ) == 0 ) {
+		strcpy( membuff, OCSPPASS_REVOKED );
+	} else if ( strcmp( refname, OCSPCRED_NORESP ) == 0 ) {
+		strcpy( membuff, OCSPPASS_NORESP );
 	} else {
 		retval =  RDKCONFIG_FAIL;
 	}

--- a/test/l2-sampleapp/certsel_xsign.c
+++ b/test/l2-sampleapp/certsel_xsign.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2025 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * certsel_xsign.c — L2 test sequences 9-17
+ *
+ * Covers:
+ *   Seq 9-11  : Cross-signed mTLS (XSign)
+ *   Seq 12-13 : CRL revocation
+ *   Seq 14-16 : OCSP stapling
+ *   Seq 17    : Cross-signed bridge expiry mid-session
+ *
+ * All sequences feed synthetic curl error codes via certGetAndSet() —
+ * no real TLS connections are made. Placeholder P12 files in ./l2/xs/
+ * are created by test_setup.sh.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "include/l2_tst.h"
+#include "include/rdkcertselector.h"
+#include "include/unit_test.h"
+
+/* certGetAndSet is defined in certsel_seq.c and declared in l2_tst.h
+ * via the function prototype there — resolved at link time. */
+int certGetAndSet(rdkcertselector_h, unsigned int, const char *, const char *, rdkcertselectorRetry_t);
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 9 — XSign: both OldRoot and NewRoot present in CA store
+ *
+ * Config: xs_both_roots.cfg / XSGRP
+ * Certs:  [1] client-xsign.p12 (bridge embedded)
+ *
+ * Step 1: getCert → client-xsign.p12; setCurlStatus(SUCCESS) → NO_RETRY
+ * Step 2: next call reuses client-xsign.p12 → NO_RETRY
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq9cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq9cs = rdkcertselector_new(XS_CFG_BOTH, L2_HROTPROP, XSGRP);
+        L2_NOTNULL(seq9cs, "Cert selector initialization failed for sequence 9\n");
+
+        /* both roots present — xsign cert selected immediately */
+        L2_TST(certGetAndSet(seq9cs, CURL_SUCCESS, FILESCHEME XSCERT_XSIG, XSPASS_XSIG, NO_RETRY));
+        /* next call: same cert reused */
+        L2_TST(certGetAndSet(seq9cs, CURL_SUCCESS, FILESCHEME XSCERT_XSIG, XSPASS_XSIG, NO_RETRY));
+
+        rdkcertselector_free(&seq9cs);
+        L2_NULL(seq9cs, "Cert selector memory free failed for sequence 9\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 10 — XSign: OldRoot expires; operator migrates to new-root config
+ *
+ * Phase A — xs_old_root_only.cfg / XSOLDGRP
+ *   Step 1: old cert works         → SUCCESS / NO_RETRY
+ *   Step 2: OldRoot expired on SVR → CACERT(60) / NO_RETRY
+ *            (server-side trust failure — selector does NOT try another cert)
+ *
+ * Phase B — xs_new_root_only.cfg / XSNEWGRP (new session after config migration)
+ *   Step 3: xsign cert via bridge  → SUCCESS / NO_RETRY
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq10cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+
+        /* ── Phase A: old-root-only config ── */
+        rdkcertselector_h seq10a = rdkcertselector_new(XS_CFG_OLD, L2_HROTPROP, XSOLDGRP);
+        L2_NOTNULL(seq10a, "Cert selector init failed for sequence 10 phase A\n");
+
+        /* old cert works */
+        L2_TST(certGetAndSet(seq10a, CURL_SUCCESS, FILESCHEME XSCERT_OLD, XSPASS_OLD, NO_RETRY));
+        /* OldRoot expires on the server side — server sends CACERT error;
+         * certsel maps CURLERR_CACERT → NO_RETRY (server trust failure, not
+         * a local cert problem — don't try another client cert) */
+        L2_TST(certGetAndSet(seq10a, CURLERR_CACERT, FILESCHEME XSCERT_OLD, XSPASS_OLD, NO_RETRY));
+
+        rdkcertselector_free(&seq10a);
+        L2_NULL(seq10a, "Cert selector memory free failed for sequence 10 phase A\n");
+
+        /* ── Phase B: new-root-only config (config migrated by operator) ── */
+        rdkcertselector_h seq10b = rdkcertselector_new(XS_CFG_NEW, L2_HROTPROP, XSNEWGRP);
+        L2_NOTNULL(seq10b, "Cert selector init failed for sequence 10 phase B\n");
+
+        /* xsign cert succeeds via cross-signed bridge to NewRoot */
+        L2_TST(certGetAndSet(seq10b, CURL_SUCCESS, FILESCHEME XSCERT_XSIG, XSPASS_NEWONLY, NO_RETRY));
+
+        rdkcertselector_free(&seq10b);
+        L2_NULL(seq10b, "Cert selector memory free failed for sequence 10 phase B\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 11 — XSign: NewRoot absent from CA store
+ *
+ * Config: xs_new_root_only.cfg / XSNEWGRP
+ * Certs:  [1] client-xsign.p12  [2] client-old.p12
+ *
+ * Client trust store has only OldRoot — server cert (signed by NewRoot)
+ * cannot be verified; both certs fail with CURLERR_ISSUER → NoCert state.
+ *
+ * Step 1: xsign cert → ISSUER(80) / TRY_ANOTHER
+ * Step 2: old cert  → ISSUER(80) / NO_RETRY  (NoCert — no more certs)
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq11cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq11cs = rdkcertselector_new(XS_CFG_NEW, L2_HROTPROP, XSNEWGRP);
+        L2_NOTNULL(seq11cs, "Cert selector initialization failed for sequence 11\n");
+
+        /* NewRoot absent — server cert unverifiable by client */
+        L2_TST(certGetAndSet(seq11cs, CURLERR_ISSUER, FILESCHEME XSCERT_XSIG, XSPASS_NEWONLY, TRY_ANOTHER));
+        /* fallback old cert also fails (same issuer chain failure) → NoCert */
+        L2_TST(certGetAndSet(seq11cs, CURLERR_ISSUER, FILESCHEME XSCERT_OLD, XSPASS_OLD, NO_RETRY));
+
+        rdkcertselector_free(&seq11cs);
+        L2_NULL(seq11cs, "Cert selector memory free failed for sequence 11\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 12 — CRL: leaf cert is on the CRL
+ *
+ * Config: xs_crl.cfg / CRLGRP
+ * Certs:  [1] crl-revoked.p12  [2] crl-valid.p12
+ *
+ * Step 1: revoked cert  → CERTSTATUS(91) / TRY_ANOTHER
+ * Step 2: valid cert    → SUCCESS / NO_RETRY
+ * Step 3: next call skips revoked, uses valid directly
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq12cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq12cs = rdkcertselector_new(XS_CFG_CRL, L2_HROTPROP, CRLGRP);
+        L2_NOTNULL(seq12cs, "Cert selector initialization failed for sequence 12\n");
+
+        /* revoked leaf cert triggers CRL status failure */
+        L2_TST(certGetAndSet(seq12cs, CURLERR_CERTSTATUS, FILESCHEME CRLCERT_REVOKED, CRLPASS_REVOKED, TRY_ANOTHER));
+        /* valid cert selected */
+        L2_TST(certGetAndSet(seq12cs, CURL_SUCCESS, FILESCHEME CRLCERT_VALID, CRLPASS_VALID, NO_RETRY));
+        /* subsequent call: revoked cert permanently skipped, valid cert reused */
+        L2_TST(certGetAndSet(seq12cs, CURL_SUCCESS, FILESCHEME CRLCERT_VALID, CRLPASS_VALID, NO_RETRY));
+
+        rdkcertselector_free(&seq12cs);
+        L2_NULL(seq12cs, "Cert selector memory free failed for sequence 12\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 13 — CRL: intermediate CA is revoked
+ *
+ * Config: xs_crl.cfg / ICAGRP
+ * Certs:  [1] ica-revoked-leaf.p12  [2] ica-valid-leaf.p12
+ *
+ * CURLERR_ISSUER(80) signals that the ICA's chain cannot be verified
+ * (ICA is on the CRL — issuer of the leaf is untrusted).
+ *
+ * Step 1: revoked ICA leaf → ISSUER(80) / TRY_ANOTHER
+ * Step 2: valid ICA leaf   → SUCCESS / NO_RETRY
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq13cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq13cs = rdkcertselector_new(XS_CFG_CRL, L2_HROTPROP, ICAGRP);
+        L2_NOTNULL(seq13cs, "Cert selector initialization failed for sequence 13\n");
+
+        /* leaf under revoked ICA — issuer chain failure */
+        L2_TST(certGetAndSet(seq13cs, CURLERR_ISSUER, FILESCHEME ICACERT_REVOKED, ICAPASS_REVOKED, TRY_ANOTHER));
+        /* leaf under valid ICA succeeds */
+        L2_TST(certGetAndSet(seq13cs, CURL_SUCCESS, FILESCHEME ICACERT_VALID, ICAPASS_VALID, NO_RETRY));
+
+        rdkcertselector_free(&seq13cs);
+        L2_NULL(seq13cs, "Cert selector memory free failed for sequence 13\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 14 — OCSP: server staples a good OCSP response
+ *
+ * Config: xs_ocsp.cfg / OCSPGOODGRP
+ * Certs:  [1] ocsp-valid.p12
+ *
+ * Step 1: good OCSP status → SUCCESS / NO_RETRY
+ * Step 2: reused on next call
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq14cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq14cs = rdkcertselector_new(XS_CFG_OCSP, L2_HROTPROP, OCSPGOODGRP);
+        L2_NOTNULL(seq14cs, "Cert selector initialization failed for sequence 14\n");
+
+        /* good OCSP — cert selected without fallback */
+        L2_TST(certGetAndSet(seq14cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+        /* reused */
+        L2_TST(certGetAndSet(seq14cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+
+        rdkcertselector_free(&seq14cs);
+        L2_NULL(seq14cs, "Cert selector memory free failed for sequence 14\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 15 — OCSP: server staples a revoked OCSP response
+ *
+ * Config: xs_ocsp.cfg / OCSPGRP
+ * Certs:  [1] ocsp-revoked.p12  [2] ocsp-valid.p12
+ *
+ * Step 1: revoked OCSP → CERTSTATUS(91) / TRY_ANOTHER
+ * Step 2: valid cert   → SUCCESS / NO_RETRY
+ * Step 3: revoked cert stays skipped, valid cert reused
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq15cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq15cs = rdkcertselector_new(XS_CFG_OCSP, L2_HROTPROP, OCSPGRP);
+        L2_NOTNULL(seq15cs, "Cert selector initialization failed for sequence 15\n");
+
+        /* revoked OCSP status */
+        L2_TST(certGetAndSet(seq15cs, CURLERR_CERTSTATUS, FILESCHEME OCSPCERT_REVOKED, OCSPPASS_REVOKED, TRY_ANOTHER));
+        /* fallback to valid cert */
+        L2_TST(certGetAndSet(seq15cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+        /* revoked cert stays skipped */
+        L2_TST(certGetAndSet(seq15cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+
+        rdkcertselector_free(&seq15cs);
+        L2_NULL(seq15cs, "Cert selector memory free failed for sequence 15\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 16 — OCSP hard-fail: OCSP responder unreachable
+ *
+ * Config: xs_ocsp.cfg / OCSPNRGRP
+ * Certs:  [1] ocsp-noresponder.p12  [2] ocsp-valid.p12
+ *
+ * Step 1: noresponder → CERTSTATUS(91) / TRY_ANOTHER
+ * Step 2: fallback to valid cert → SUCCESS / NO_RETRY
+ * Step 3: noresponder stays skipped → valid cert reused
+ * Step 4: touch noresponder file (simulates cert renewal after responder recovery)
+ * Step 5: noresponder cert reused → SUCCESS / NO_RETRY
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq16cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq16cs = rdkcertselector_new(XS_CFG_OCSP, L2_HROTPROP, OCSPNRGRP);
+        L2_NOTNULL(seq16cs, "Cert selector initialization failed for sequence 16\n");
+
+        /* OCSP responder unreachable — hard-fail */
+        L2_TST(certGetAndSet(seq16cs, CURLERR_CERTSTATUS, FILESCHEME OCSPCERT_NORESP, OCSPPASS_NORESP, TRY_ANOTHER));
+        /* fallback cert used */
+        L2_TST(certGetAndSet(seq16cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+        /* noresponder cert still skipped */
+        L2_TST(certGetAndSet(seq16cs, CURL_SUCCESS, FILESCHEME OCSPCERT_VALID, OCSPPASS_VALID, NO_RETRY));
+
+        /* responder recovers — simulate cert renewal by updating file timestamp */
+        sleep(1);
+        UT_SYSTEM0("touch " OCSPCERT_NORESP);
+
+        /* noresponder cert is now fresh — selector reselects it */
+        L2_TST(certGetAndSet(seq16cs, CURL_SUCCESS, FILESCHEME OCSPCERT_NORESP, OCSPPASS_NORESP, NO_RETRY));
+
+        rdkcertselector_free(&seq16cs);
+        L2_NULL(seq16cs, "Cert selector memory free failed for sequence 16\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Sequence 17 — XSign bridge expiry mid-session
+ *
+ * Config: xs_expxs.cfg / EXPXSGRP
+ * Certs:  [1] client-expxs.p12 (expired bridge)  [2] client-new.p12
+ *
+ * Step 1: first call with valid bridge     → SUCCESS / NO_RETRY
+ * Step 2: bridge expires mid-session       → ISSUER(80) / TRY_ANOTHER
+ * Step 3: fallback to new-root cert        → SUCCESS / NO_RETRY
+ * Step 4: expxs cert stays skipped         → new-root cert reused
+ * Step 5: touch expxs (simulate reissuance of bundle with fresh bridge)
+ * Step 6: expxs cert freshened             → SUCCESS / NO_RETRY
+ * ──────────────────────────────────────────────────────────────────────────*/
+int run_seq17cs()
+{
+        DEBUG_LOG("%s : Entry\n", __FUNCTION__);
+        rdkcertselector_h seq17cs = rdkcertselector_new(XS_CFG_EXPXS, L2_HROTPROP, EXPXSGRP);
+        L2_NOTNULL(seq17cs, "Cert selector initialization failed for sequence 17\n");
+
+        /* first call — bridge still valid */
+        L2_TST(certGetAndSet(seq17cs, CURL_SUCCESS, FILESCHEME XSCERT_EXPXS, XSPASS_EXPXS, NO_RETRY));
+
+        /* bridge expires mid-session — issuer chain failure */
+        L2_TST(certGetAndSet(seq17cs, CURLERR_ISSUER, FILESCHEME XSCERT_EXPXS, XSPASS_EXPXS, TRY_ANOTHER));
+        /* new-root cert takes over */
+        L2_TST(certGetAndSet(seq17cs, CURL_SUCCESS, FILESCHEME XSCERT_NEW, XSPASS_NEW, NO_RETRY));
+        /* expired-bridge cert stays skipped */
+        L2_TST(certGetAndSet(seq17cs, CURL_SUCCESS, FILESCHEME XSCERT_NEW, XSPASS_NEW, NO_RETRY));
+
+        /* simulate bundle reissuance with fresh bridge */
+        sleep(1);
+        UT_SYSTEM0("touch " XSCERT_EXPXS);
+
+        /* expxs cert freshened — reselected */
+        L2_TST(certGetAndSet(seq17cs, CURL_SUCCESS, FILESCHEME XSCERT_EXPXS, XSPASS_EXPXS, NO_RETRY));
+
+        rdkcertselector_free(&seq17cs);
+        L2_NULL(seq17cs, "Cert selector memory free failed for sequence 17\n");
+        DEBUG_LOG("%s : End\n", __FUNCTION__);
+        return L2_SUCCESS;
+}

--- a/test/l2-sampleapp/include/l2_tst.h
+++ b/test/l2-sampleapp/include/l2_tst.h
@@ -28,6 +28,16 @@ int run_seq5cs();
 int run_seq6cs();
 int run_dualseq1cs();
 int run_badseq1();
+/* Cross-signed / CRL / OCSP sequences (9-17) */
+int run_seq9cs();
+int run_seq10cs();
+int run_seq11cs();
+int run_seq12cs();
+int run_seq13cs();
+int run_seq14cs();
+int run_seq15cs();
+int run_seq16cs();
+int run_seq17cs();
 
 #define RDK_LOG(a1, a2, args...) fprintf(stderr, args)
 #define RDK_LOG_INFO 0
@@ -40,7 +50,10 @@ int run_badseq1();
 
 #define L2_HROTPROP  "./l2/etc/ssl/certsel/hrot.properties"
 #define FILESCHEME "file://"
-#define CURLERR_LOCALCERT 58
+#define CURLERR_LOCALCERT   58  /* CURLE_SSL_CERTPROBLEM  - local cert error   */
+#define CURLERR_CACERT      60  /* CURLE_SSL_CACERT       - server CA failure   */
+#define CURLERR_ISSUER      80  /* CURLE_SSL_ISSUER_ERROR - issuer chain error  */
+#define CURLERR_CERTSTATUS  91  /* CURLE_SSL_INVALIDCERTSTATUS - CRL/OCSP revoked */
 #define CURLERR_NONCERT 1
 #define CURL_SUCCESS 0
 #define L2_SUCCESS 0
@@ -70,6 +83,69 @@ int run_badseq1();
 #define UTPASS2 UTCRED2 "pass"
 #define UTPASS3 UTCRED3 "pass"
 #define UTPASSALPHA UTCREDALPHA "pass"
+
+/* ── Cross-signed / CRL / OCSP cert paths (sequences 9-17) ── */
+#define XSDIR           UTDIR "/xs"
+
+/* cert file paths */
+#define XSCERT_XSIG     XSDIR "/client-xsign.p12"
+#define XSCERT_OLD      XSDIR "/client-old.p12"
+#define XSCERT_NEW      XSDIR "/client-new.p12"
+#define XSCERT_EXPXS    XSDIR "/client-expxs.p12"
+#define CRLCERT_REVOKED XSDIR "/crl-revoked.p12"
+#define CRLCERT_VALID   XSDIR "/crl-valid.p12"
+#define ICACERT_REVOKED XSDIR "/ica-revoked-leaf.p12"
+#define ICACERT_VALID   XSDIR "/ica-valid-leaf.p12"
+#define OCSPCERT_VALID  XSDIR "/ocsp-valid.p12"
+#define OCSPCERT_REVOKED XSDIR "/ocsp-revoked.p12"
+#define OCSPCERT_NORESP  XSDIR "/ocsp-noresponder.p12"
+
+/* credential refs */
+#define XSCRED_XSIG     "xs-client"
+#define XSCRED_OLD      "xs-old"
+#define XSCRED_NEW      "xs-new"
+#define XSCRED_EXPXS    "xs-expxs"
+#define XSCRED_NEWONLY  "xs-newonly"
+#define CRLCRED_REVOKED "crl-revoked"
+#define CRLCRED_VALID   "crl-valid"
+#define ICACRED_REVOKED "ica-revoked"
+#define ICACRED_VALID   "ica-valid"
+#define OCSPCRED_VALID  "ocsp-good"
+#define OCSPCRED_REVOKED "ocsp-revoked"
+#define OCSPCRED_NORESP  "ocsp-noresponder"
+
+/* passwords (credref + "pass") */
+#define XSPASS_XSIG     XSCRED_XSIG "pass"
+#define XSPASS_OLD      XSCRED_OLD "pass"
+#define XSPASS_NEW      XSCRED_NEW "pass"
+#define XSPASS_EXPXS    XSCRED_EXPXS "pass"
+#define XSPASS_NEWONLY  XSCRED_NEWONLY "pass"
+#define CRLPASS_REVOKED CRLCRED_REVOKED "pass"
+#define CRLPASS_VALID   CRLCRED_VALID "pass"
+#define ICAPASS_REVOKED ICACRED_REVOKED "pass"
+#define ICAPASS_VALID   ICACRED_VALID "pass"
+#define OCSPPASS_VALID  OCSPCRED_VALID "pass"
+#define OCSPPASS_REVOKED OCSPCRED_REVOKED "pass"
+#define OCSPPASS_NORESP  OCSPCRED_NORESP "pass"
+
+/* certsel config files */
+#define XS_CFG_BOTH  XSDIR "/xs_both_roots.cfg"
+#define XS_CFG_OLD   XSDIR "/xs_old_root_only.cfg"
+#define XS_CFG_NEW   XSDIR "/xs_new_root_only.cfg"
+#define XS_CFG_CRL   XSDIR "/xs_crl.cfg"
+#define XS_CFG_OCSP  XSDIR "/xs_ocsp.cfg"
+#define XS_CFG_EXPXS XSDIR "/xs_expxs.cfg"
+
+/* certsel groups */
+#define XSGRP    "XSGRP"
+#define XSOLDGRP "XSOLDGRP"
+#define XSNEWGRP "XSNEWGRP"
+#define CRLGRP   "CRLGRP"
+#define ICAGRP   "ICAGRP"
+#define OCSPGOODGRP "OCSPGOODGRP"
+#define OCSPGRP     "OCSPGRP"
+#define OCSPNRGRP   "OCSPNRGRP"
+#define EXPXSGRP    "EXPXSGRP"
 
 #define GETSZ 50
 #define RDKCONFIG_OK 0

--- a/test/l2-sampleapp/test_setup.sh
+++ b/test/l2-sampleapp/test_setup.sh
@@ -37,3 +37,46 @@ echo "\nhrotengine=e4tst1" > ./l2/tst2hrot.properties
 echo "hrotprovider=e4tst1" > ./l2/bad3hrot.properties
 echo -n "GRP1,FRST,TMP,t1.tmp,pc1" > ./l2/tst1toolong.cfg
 
+# ── Cross-signed / CRL / OCSP test setup (sequences 9-17) ──────────────────
+mkdir -p ./l2/xs
+
+# 3.1 Placeholder P12 files (touch is sufficient for L2 state-machine tests)
+touch ./l2/xs/client-xsign.p12
+touch ./l2/xs/client-old.p12
+touch ./l2/xs/client-new.p12
+touch ./l2/xs/client-expxs.p12
+touch ./l2/xs/crl-revoked.p12
+touch ./l2/xs/crl-valid.p12
+touch ./l2/xs/ica-valid-leaf.p12
+touch ./l2/xs/ica-revoked-leaf.p12
+touch ./l2/xs/ocsp-valid.p12
+touch ./l2/xs/ocsp-revoked.p12
+touch ./l2/xs/ocsp-noresponder.p12
+
+# 3.2 xs_both_roots.cfg — both roots trusted; xsign cert (seq 9)
+echo "XSGRP,XSIG,TMP,file://./l2/xs/client-xsign.p12,xs-client" > ./l2/xs/xs_both_roots.cfg
+
+# 3.3 xs_old_root_only.cfg — old-root-only config (seq 10 phase A)
+echo "XSOLDGRP,OLD,TMP,file://./l2/xs/client-old.p12,xs-old" > ./l2/xs/xs_old_root_only.cfg
+
+# 3.4 xs_new_root_only.cfg — new-root-only config (seq 10 phase B, seq 11)
+echo "XSNEWGRP,XSIG,TMP,file://./l2/xs/client-xsign.p12,xs-newonly" > ./l2/xs/xs_new_root_only.cfg
+echo "XSNEWGRP,OLD,TMP,file://./l2/xs/client-old.p12,xs-old" >> ./l2/xs/xs_new_root_only.cfg
+
+# 3.5 xs_crl.cfg — CRL revocation (seq 12: CRLGRP, seq 13: ICAGRP)
+echo "CRLGRP,REVO,TMP,file://./l2/xs/crl-revoked.p12,crl-revoked" > ./l2/xs/xs_crl.cfg
+echo "CRLGRP,VALI,TMP,file://./l2/xs/crl-valid.p12,crl-valid" >> ./l2/xs/xs_crl.cfg
+echo "ICAGRP,REVO,TMP,file://./l2/xs/ica-revoked-leaf.p12,ica-revoked" >> ./l2/xs/xs_crl.cfg
+echo "ICAGRP,VALI,TMP,file://./l2/xs/ica-valid-leaf.p12,ica-valid" >> ./l2/xs/xs_crl.cfg
+
+# 3.6 xs_ocsp.cfg — OCSP scenarios (seq 14: OCSPGOODGRP, seq 15: OCSPGRP, seq 16: OCSPNRGRP)
+echo "OCSPGOODGRP,GOOD,TMP,file://./l2/xs/ocsp-valid.p12,ocsp-good" > ./l2/xs/xs_ocsp.cfg
+echo "OCSPGRP,REVO,TMP,file://./l2/xs/ocsp-revoked.p12,ocsp-revoked" >> ./l2/xs/xs_ocsp.cfg
+echo "OCSPGRP,GOOD,TMP,file://./l2/xs/ocsp-valid.p12,ocsp-good" >> ./l2/xs/xs_ocsp.cfg
+echo "OCSPNRGRP,NOR,TMP,file://./l2/xs/ocsp-noresponder.p12,ocsp-noresponder" >> ./l2/xs/xs_ocsp.cfg
+echo "OCSPNRGRP,GOOD,TMP,file://./l2/xs/ocsp-valid.p12,ocsp-good" >> ./l2/xs/xs_ocsp.cfg
+
+# 3.7 xs_expxs.cfg — bridge-expiry (seq 17)
+echo "EXPXSGRP,EXPX,TMP,file://./l2/xs/client-expxs.p12,xs-expxs" > ./l2/xs/xs_expxs.cfg
+echo "EXPXSGRP,NEWC,TMP,file://./l2/xs/client-new.p12,xs-new" >> ./l2/xs/xs_expxs.cfg
+


### PR DESCRIPTION
- certsel_xsign.c: new L2 test sequences 9-17 (XSign, CRL, OCSP, bridge expiry)
- generate_cross_signed_test_certs.sh: on-demand cross-signed PKI generator
- l2_tst.h: CURLERR_ISSUER/CERTSTATUS/CACERT constants, XSDIR macros, seq9-17 decls
- certsel_seq.c: extended rdkconfig_getStr mock for new credential refs
- certsel_main.c: dispatch cases 9-17
- Makefile.am: certsel_xsign.c added to l2sampleapp_SOURCES
- test_setup.sh: l2/xs/ dir, placeholder P12s, certsel config files
- test_certsel_seq.py: sequence_descriptions extended for seqs 9-17
- sequ9_11_xsign.feature, sequ12_13_crl.feature, sequ14_17_ocsp_xsexpiry.feature: BDD scenarios